### PR TITLE
rename Datenschutz to Datenschutzerklärung

### DIFF
--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -130,7 +130,7 @@
       {% if theme_var('footer.datenschutz.enabled') %}
         &nbsp;|&nbsp;
         <a href="{{ base_url }}{{ theme_var('footer.datenschutz.link') }}">
-          Datenschutz
+          Datenschutzerklärung
         </a>
       {% endif %}
     </div>


### PR DESCRIPTION
Thank you for providing this great theme!

In my case, it's not possible to click the "Datenschutz" link because when clicking, the hover effect gets added and then the "Impressum" link is opened instead. This issue occurs because the email has 28 characters. Renaming it fixed the issue.

On the other hand, the official name is "Datenschutzerklärung". ([https://de.wikipedia.org/wiki/Datenschutzerklärung](https://de.wikipedia.org/wiki/Datenschutzerkl%C3%A4rung))

If you have any questions, please let me know.